### PR TITLE
make save and load os independent; add uv to pre-commit to .toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,4 +12,9 @@ repos:
     - id: ruff-format
       types_or: [ python, pyi ]
       files: .*
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    # uv version.
+    rev: 0.6.10
+    hooks:
+      - id: uv-lock
 files: ''

--- a/baguetter/indices/sparse/base.py
+++ b/baguetter/indices/sparse/base.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
     from baguetter.types import Key, TextOrTokens
-    from baguetter.utils.file_repository import AbstractFileRepository
 
 
 class BaseSparseIndex(BaseIndex, abc.ABC):
@@ -162,7 +161,6 @@ class BaseSparseIndex(BaseIndex, abc.ABC):
     def _save(
         self,
         path: str,
-        repository: AbstractFileRepository,
     ) -> str:
         """Save the index to the given path.
 
@@ -177,7 +175,7 @@ class BaseSparseIndex(BaseIndex, abc.ABC):
             "corpus_tokens": self.corpus_tokens,
             "config": dataclasses.asdict(self.config),
         }
-        with repository.open(path, "wb") as f:
+        with open(path, "wb") as f:
             np.savez_compressed(f, state=state)
         return path
 
@@ -185,7 +183,6 @@ class BaseSparseIndex(BaseIndex, abc.ABC):
     def _load(
         cls,
         path: str,
-        repository: AbstractFileRepository,
         *,
         mmap: bool = False,
     ) -> BaseSparseIndex:
@@ -203,12 +200,12 @@ class BaseSparseIndex(BaseIndex, abc.ABC):
             FileNotFoundError: If the index file is not found.
 
         """
-        if not repository.exists(path):
+        if not os.path.exists(path):
             msg = f"Index {path} not found."
             raise FileNotFoundError(msg)
 
         mmap_mode = "r" if mmap else None
-        with repository.open(path, "rb") as f:
+        with open(path, "rb") as f:
             stored = np.load(f, allow_pickle=True, mmap_mode=mmap_mode)
             state = stored["state"][()]
             retriever = cls.from_config(SparseIndexConfig(**state["config"]))

--- a/baguetter/utils/file_repository.py
+++ b/baguetter/utils/file_repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from fsspec import AbstractFileSystem
@@ -103,12 +104,13 @@ class LocalFileRepository(AbstractFileRepository, LocalFileSystem):
 
         """
         super().__init__(**kwargs)
-        self._base_path = str(Path(path or f"{settings.base_path}/repository").resolve())
-        if not self.isdir(self._base_path):
-            if self.exists(self._base_path):
-                msg = f"Path '{self._base_path}' exists but is not a directory."
+        base_path = str(Path(path or f"{settings.base_path}/repository").resolve())
+        if not os.path.isdir(base_path):
+            if os.path.exists(base_path):
+                msg = f"Path '{base_path}' exists but is not a directory."
                 raise ValueError(msg)
-            self.mkdir(self._base_path, parents=True, exist_ok=True)
+            os.makedirs(base_path, exist_ok=True)
+        self._base_path = base_path
 
     def _strip_protocol(self, path: str) -> str:
         """Strip the protocol from the given path.

--- a/baguetter/utils/persistable.py
+++ b/baguetter/utils/persistable.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import os
 from abc import ABC, abstractmethod
 from typing import Any
 
-from baguetter.utils.file_repository import AbstractFileRepository, HuggingFaceFileRepository, LocalFileRepository
-
+from baguetter.utils.file_repository import HuggingFaceFileRepository
 
 class Persistable(ABC):
     """Abstract base class for objects that can be persisted to and loaded from storage.
@@ -18,7 +18,6 @@ class Persistable(ABC):
     def _load(
         cls,
         path: str,
-        repository: AbstractFileRepository,
         *,
         allow_pickle: bool = True,
         mmap: bool = False,
@@ -27,7 +26,6 @@ class Persistable(ABC):
 
         Args:
             path (str): Path of the object to load.
-            repository (AbstractFileRepository): File repository to load from.
             allow_pickle (bool, optional): Whether to allow loading pickled objects. Defaults to True.
             mmap (bool, optional): Whether to memory-map the file. Defaults to False.
 
@@ -37,12 +35,11 @@ class Persistable(ABC):
         """
 
     @abstractmethod
-    def _save(self, path: str, repository: AbstractFileRepository) -> str:
+    def _save(self, path: str) -> str:
         """Save the object to storage.
 
         Args:
             path (str): Path to save the object to.
-            repository (AbstractFileRepository): File repository to save to.
 
         Returns:
             str: Path to the saved object.
@@ -59,12 +56,8 @@ class Persistable(ABC):
             str: Path to the saved object.
 
         """
-        repository = LocalFileRepository()
-        directory = path.rsplit("/", 1)
-        if len(directory) > 1:
-            repository.mkdirs(directory[0], exist_ok=True)
-        path = self._save(path=path, repository=repository)
-        return repository.info(path)["name"]
+        path = self._save(path=path)
+        return os.path.basename(path)
 
     @classmethod
     def load(cls, path: str, *, mmap: bool = False) -> Any:
@@ -78,10 +71,8 @@ class Persistable(ABC):
             Any: The loaded object.
 
         """
-        repository = LocalFileRepository()
         return cls._load(
             path=path,
-            repository=repository,
             mmap=mmap,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,8 @@ include = ["baguetter", "baguetter.*"]
 
 [tool.setuptools.package-data]
 baguetter = ["py.typed"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.5",
+]

--- a/tests/indices/dense/faiss_test.py
+++ b/tests/indices/dense/faiss_test.py
@@ -6,7 +6,6 @@ import pytest
 
 from baguetter.indices.base import SearchResults
 from baguetter.indices.dense.faiss import FaissDenseIndex
-from baguetter.utils.file_repository import LocalFileRepository
 
 
 @pytest.fixture
@@ -100,10 +99,9 @@ def test_faiss_save_and_load(sample_data):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         save_path = "faiss_index"
-        repo = LocalFileRepository(tmpdir)
-        index._save(repository=repo, path=save_path)
+        index._save(path=save_path)
 
-        loaded_index = FaissDenseIndex._load(save_path, repository=repo)
+        loaded_index = FaissDenseIndex._load(save_path)
 
         assert loaded_index.size == index.size
         assert loaded_index.config.__dict__ == index.config.__dict__

--- a/tests/indices/dense/usearch_test.py
+++ b/tests/indices/dense/usearch_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import tempfile
 
 import numpy as np
@@ -8,7 +9,6 @@ import pytest
 from baguetter.indices.dense.base import _INDEX_PREFIX
 from baguetter.indices.dense.config import DenseIndexConfig
 from baguetter.indices.dense.usearch import USearchDenseIndex
-from baguetter.utils.file_repository import LocalFileRepository
 
 
 @pytest.fixture
@@ -94,13 +94,12 @@ def test_usearch_save_load(sample_data):
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         save_path = "usearch_new-index"
-        repository = LocalFileRepository(tmp_dir)
 
         # Save the index
-        index._save(path=save_path, repository=repository)
+        index._save(path=save_path)
 
         # Load the index
-        loaded_index = USearchDenseIndex._load(path=save_path, repository=repository)
+        loaded_index = USearchDenseIndex._load(path=save_path)
 
         assert loaded_index.config.embedding_dim == 128
         assert loaded_index.key_counter == 10
@@ -116,8 +115,8 @@ def test_usearch_save_load(sample_data):
         )
 
         # Verify file names
-        assert repository.exists(save_path)
-        assert repository.exists(f"{_INDEX_PREFIX}{save_path}")
+        assert os.path.exists(save_path)
+        assert os.path.exists(f"{_INDEX_PREFIX}{save_path}")
 
 
 def test_usearch_embed_function():


### PR DESCRIPTION
Hi there,

Based on this [issue](https://github.com/mixedbread-ai/baguetter/issues/9) I am proposing to you a PR that makes the save and load methods of sparse base index + dense faiss and usearch indices. 

The goal is to make baguetter windows compatible.

The problem comes from the fsspec lib and its usage in the LocalFileRepository component.

My approach was to work backwards from there and using the os module to decouple baguetter from fsspec. In the end, the solution practically does away with the LocalFileRepository component, which is rendered useless. But, I kept it as this should be a bigger design decision. Let me know your thoughts.

Right now on a windows machine we get 100% test coverage, whereas before there were 3 errors (on test_base.py, test_faiss.py, and test_usearch.py) which all stemmed from the save and load functions.

![test_baguetter](https://github.com/user-attachments/assets/420e28a7-70aa-405d-ba6b-b769a3afcce0)

Some changes were done to the tests to align with dropping the LocalFileRepository component after first getting 100% code coverage while keeping the component intact.

Please test it in Linux and/or Mac and let me know if it breaks anything there.

Also added uv to pre-commit and pyproject.toml to enable direct usage with uv (by simply running `uv sync` on your clone/fork of the repo).